### PR TITLE
#7 Updating redirect to use shared invite link and adding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 # Slack Inviter Redirect
 
-Redirects traffic from slack.lansing.codes to our Slack inviter, which is
-hosted at https://lansingcodes-slackin.herokuapp.com for free on Heroku.
+Redirects traffic from slack.lansing.codes to our "shared invites" link. The link can be accessed by a Slack administrator at [https://lansingcodes.slack.com/admin/shared_invites](https://lansingcodes.slack.com/admin/shared_invites). Note that these links expire after 9 months, so a reminder should be added to the leadership Slack channel to ensure the URL is updated through a PR to this repo, replacing all references to https://join.slack.com/t/lansingcodes/shared_invite in index.html to reference the invite token.
 
 This project is hosted online using Netlify. A DNS CNAME record points
 `slack[.lansing.codes]` at the website, which then directs traffic to the

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
     <title>Redirecting</title>
     <meta
       http-equiv="Refresh"
-      content="0; url=https://lansingcodes-slackin.herokuapp.com/"
+      content="0; url=https://join.slack.com/t/lansingcodes/shared_invite/zt-e1lf2l7a-e44lYpK2FMeQd4WJzjQJ2Q/"
     >
   </head>
   <body>
     <p>
       If you are not automatically redirected, please go to
       <a
-        href="https://lansingcodes-slackin.herokuapp.com"
-      >https://lansingcodes-slackin.herokuapp.com</a>.
+        href="https://join.slack.com/t/lansingcodes/shared_invite/zt-e1lf2l7a-e44lYpK2FMeQd4WJzjQJ2Q"
+      >https://join.slack.com/t/lansingcodes/shared_invite/zt-e1lf2l7a-e44lYpK2FMeQd4WJzjQJ2Q</a>.
     </p>
   </body>
 </html>


### PR DESCRIPTION
Updates the redirect URI to use the Slack "shared invite" link capability and adds documentation on how a new link can be found when it is time to be replaced, since they expire after 9 months.